### PR TITLE
Add goo values for normal BOP log types

### DIFF
--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_cherry_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_cherry_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:cherry_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_fir_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_fir_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:fir_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_jacaranda_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_jacaranda_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:jacaranda_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_mahogany_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_mahogany_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:mahogany_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_palm_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_palm_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:palm_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_redwood_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_redwood_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:redwood_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_cherry_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_cherry_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_cherry_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_fir_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_fir_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_fir_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_jacaranda_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_jacaranda_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_jacaranda_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_mahogany_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_mahogany_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_jacaranda_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_palm_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_palm_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_palm_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_redwood_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_redwood_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_redwood_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_willow_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_stripped_willow_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:stripped_willow_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}

--- a/data/goo/aequivaleo/locked/general/item_biomesoplenty_willow_log.json
+++ b/data/goo/aequivaleo/locked/general/item_biomesoplenty_willow_log.json
@@ -1,0 +1,20 @@
+{
+  "mode": "ADDITIVE",
+  "target": {
+    "type": "aequivaleo:item",
+    "data": {
+      "count": 1.0,
+      "item": "biomesoplenty:willow_log"
+    }
+  },
+  "compounds": [
+    {
+      "amount": 128.0,
+      "type": "goo:floral"
+    },
+    {
+      "amount": 16.0,
+      "type": "goo:vital"
+    }
+  ]
+}


### PR DESCRIPTION
The jsons for adding the log goo values to BOP's vanilla-equivalent logs.

The 4 BOP log types which are not immediately vanilla-equivalent (Dead, Magic, Umbran, Hellbark) have been left out at the moment, as non-standard goo values may fit better for those.